### PR TITLE
docs: fix maintainer information

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,1 +1,1 @@
-Alexander Ioannidis <a.ioannidis@cern.ch>
+Alexander Ioannidis <a.ioannidis@cern.ch> (@slint)


### PR DESCRIPTION
* Adds missing GitHub ID to the MAINTAINERS file. (This is necessary for
  good LGTM operation.)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>